### PR TITLE
deprecated constructors

### DIFF
--- a/includes/widgets/class-realia-widget-agents-assigned.php
+++ b/includes/widgets/class-realia-widget-agents-assigned.php
@@ -18,7 +18,7 @@ class Realia_Widget_Agents_Assigned extends WP_Widget {
 	 * @access public
 	 * @return void
 	 */
-	function Realia_Widget_Agents_Assigned() {
+	function __construct() {
 		parent::__construct(
 			'agents_assigned_widget',
 			__( 'Assigned Agents', 'realia' ),

--- a/includes/widgets/class-realia-widget-agents.php
+++ b/includes/widgets/class-realia-widget-agents.php
@@ -18,7 +18,7 @@ class Realia_Widget_Agents extends WP_Widget {
 	 * @access public
 	 * @return void
 	 */
-	function Realia_Widget_Agents() {
+	function __construct() {
 		parent::__construct(
 			'agents_widget',
 			__( 'Agents', 'realia' ),

--- a/includes/widgets/class-realia-widget-enquire.php
+++ b/includes/widgets/class-realia-widget-enquire.php
@@ -18,7 +18,7 @@ class Realia_Widget_Enquire extends WP_Widget {
 	 * @access public
 	 * @return void
 	 */
-	function Realia_Widget_Enquire() {
+	function __construct() {
 		parent::__construct(
 			'enquire_widget',
 			__( 'Enquire Form', 'realia' ),

--- a/includes/widgets/class-realia-widget-filter-rent-sale.php
+++ b/includes/widgets/class-realia-widget-filter-rent-sale.php
@@ -18,7 +18,7 @@ class Realia_Widget_Filter_Rent_Sale extends WP_Widget {
 	 * @access public
 	 * @return void
 	 */
-	function Realia_Widget_Filter_Rent_Sale() {
+	function __construct() {
 		parent::__construct(
 			'filter_rent_sale_widget',
 			__( 'Rent/Sale Filter', 'realia' ),

--- a/includes/widgets/class-realia-widget-filter.php
+++ b/includes/widgets/class-realia-widget-filter.php
@@ -18,7 +18,7 @@ class Realia_Widget_Filter extends WP_Widget {
 	 * @access public
 	 * @return void
 	 */
-	function Realia_Widget_Filter() {
+	function __construct() {
 		parent::__construct(
 			'filter_widget',
 			__( 'Filter', 'realia' ),

--- a/includes/widgets/class-realia-widget-properties-map.php
+++ b/includes/widgets/class-realia-widget-properties-map.php
@@ -18,7 +18,7 @@ class Realia_Widget_Properties_Map extends WP_Widget {
 	 * @access public
 	 * @return void
 	 */
-	function Realia_Widget_Properties_Map() {
+	function __construct() {
 		parent::__construct(
 			'properties_map',
 			__( 'Properties Map', 'realia' ),

--- a/includes/widgets/class-realia-widget-properties.php
+++ b/includes/widgets/class-realia-widget-properties.php
@@ -18,7 +18,7 @@ class Realia_Widget_Properties extends WP_Widget {
 	 * @access public
 	 * @return void
 	 */
-	function Realia_Widget_Properties() {
+	function __construct() {
 		parent::__construct(
 			'properties_widget',
 			__( 'Properties', 'realia' ),


### PR DESCRIPTION
Methods with the same name as their class will not be constructors in a future version of PHP